### PR TITLE
dumper: do not crash on exceptions while rendering the request

### DIFF
--- a/Products/LongRequestLogger/dumper.py
+++ b/Products/LongRequestLogger/dumper.py
@@ -87,14 +87,17 @@ class Dumper(object):
     def format_request(self, request):
         if request is None:
             return "[No request]\n"
-        query = request.get("QUERY_STRING")
-        return REQUEST_FORMAT % {
-            "method": request["REQUEST_METHOD"],
-            "url": request.getURL() + ("?" + query if query else ""),
-            "retries": request.retry_count,
-            "form": pformat(request.form),
-            "other": pformat(request.other),
-        }
+        try:
+            query = request.get("QUERY_STRING")
+            return REQUEST_FORMAT % {
+                "method": request["REQUEST_METHOD"],
+                "url": request.getURL() + ("?" + query if query else ""),
+                "retries": request.retry_count,
+                "form": pformat(request.form),
+                "other": pformat(request.other),
+            }
+        except Exception:
+            return "[Unprintable request]\n" + traceback.format_exc()
 
     def extract_request(self, frame):
         # We try to fetch the request from the 'call_object' function because

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,8 +4,9 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Log exceptions that are raised while dumping the request. Unprintable
+  requests caused the monitor thread to die, resulting in EPIPE errors
+  in the ZPublisher wrapper.
 
 2.0.0 (2015-11-04)
 ------------------


### PR DESCRIPTION
For example, instances of App.ZApplication.ZApplicationWrapper:

    TypeError: unbound method __repr__() must be called with Application instance as first argument (got nothing instead)

(for instances of old-style classes, `__getattr__` catches `__repr__` if the latter is not defined)

The consequence is that the monitor thread crashed and next we had the following failures on each request:

    ERROR ZServerPublisher exception caught
    Traceback (most recent call last):
      File "ZServer/PubCore/ZServerPublisher.py", line 31, in __init__
        response=b)
      File "ZPublisher/Publish.py", line 455, in publish_module
        environ, debug, request, response)
      File "Products/LongRequestLogger/__init__.py", line 19, in publish_module_standard
        return publish_module_standard.original(*args, **kw)
      File "Products/LongRequestLogger/monitor.py", line 98, in __exit__
        os.write(self.event_pipe[1], '\0')
    OSError: [Errno 32] Broken pipe