### PR TITLE
dumper: do never repeat request information, traceback or SQL query i…

### DIFF
--- a/Products/LongRequestLogger/tests/common.py
+++ b/Products/LongRequestLogger/tests/common.py
@@ -11,24 +11,28 @@ class Sleeper(object):
     file where the stack trace won't be affected by editing of the test file
     that uses it.
     """
+    _start = _changing_repr_delay = float('inf')
 
-    def __init__(self, interval):
-      self.interval = interval
+    def __init__(self, *args):
+        (self._sleep1, self._sleep2, self._sleep3,
+         self._changing_repr_delay) = args
 
-    def sleep(self):
-        self._sleep1()
+    def __repr__(self):
+        now = time.time()
+        if self._start + self._changing_repr_delay < now:
+            return '<time:%r>' % now
+        return object.__repr__(self)
 
-    def _sleep1(self):
-        self._sleep2()
+    def __call__(self):
+        self._start = time.time()
+        self._sleep(self._sleep1)
+        self._sleep(self._sleep2)
+        self._sleep(self._sleep3)
 
-    def _sleep2(self):
-        time.sleep(self.interval)
-
-class App(object):
-
-    def __call__(self, interval):
-        Sleeper(interval).sleep()
-        return "OK"
+    def _sleep(self, interval):
+        time.sleep(interval)
 
 # Enable this module to be published with ZPublisher.Publish.publish_module()
-bobo_application = App()
+def bobo_application(sleeper):
+    sleeper()
+    return "OK"

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -1,12 +1,14 @@
 Changelog
 =========
 
-2.0.1 (unreleased)
+2.1.0 (unreleased)
 ------------------
 
 - Log exceptions that are raised while dumping the request. Unprintable
   requests caused the monitor thread to die, resulting in EPIPE errors
   in the ZPublisher wrapper.
+
+- Do never repeat request information, traceback or SQL query if unchanged.
 
 2.0.0 (2015-11-04)
 ------------------


### PR DESCRIPTION
…f unchanged

The body of a log consists in 3 pieces of information:
- request
- traceback
- SQL Query (sometimes)

This commit goes further than 22d7f0905a18f1445fa785ac4e0cba486e7550c2,
by not repeating any of the above 3 parts if any other changes.

This is particularly useful for the request information or the SQL query
because they can be huge while remaining the same for a long time.